### PR TITLE
Add initial deployment docs

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,15 @@
+# Deploy
+
+```bash
+kubectl create ns my-kafka-project
+kubectl -n my-kafka-project apply -f deployment/kafka/common/cluster.yaml
+kubectl -n my-kafka-project apply -f deployment/kafka/common/topic.yaml
+```
+
+# Clean up
+
+```
+kubectl delete -n my-kafka-project kafkatopic/kafka-test-apps
+kubectl -n my-kafka-project delete kafka/my-cluster
+kubectl delete ns my-kafka-project
+```

--- a/deployment/kafka/common/cluster.yaml
+++ b/deployment/kafka/common/cluster.yaml
@@ -1,0 +1,40 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    replicas: 1
+    listeners:
+      plain: {}
+#        authentication:
+#          type: scram-sha-512
+      tls: {}
+      external:
+        port: 9094
+        type: loadbalancer
+        tls: false
+#        type: nodeport
+#        tls: false
+#        authentication:
+#          type: scram-sha-512
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/deployment/kafka/common/topic.yaml
+++ b/deployment/kafka/common/topic.yaml
@@ -1,0 +1,13 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: kafka-test-apps
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 3
+  replicas: 1
+  config:
+      retention.bytes: 1073741824
+      retention.ms: 86400000
+      segment.bytes: 1073741824


### PR DESCRIPTION
I started adding resources to easily deploy kafka cluster and demo resources for different demo scenarios. The idea is that people can easily deploy just one or the other, so we can run things in different clusters (or access them from the local machines). This should eventually replace all deployment-*.yaml files from the root.

Let me know if you're OK with this concept.